### PR TITLE
Move network storage info into Pressbooks Stats, cache it

### DIFF
--- a/inc/stats/namespace.php
+++ b/inc/stats/namespace.php
@@ -2,6 +2,8 @@
 
 namespace PressbooksStats\Stats;
 
+use function Pressbooks\Utility\format_bytes;
+
 /**
  * WP hook for our very own pressbooks_track_export action
  *
@@ -476,4 +478,13 @@ function users_with_x_or_more_books( $x ) {
 	$foo = wp_list_sort( $foo, [ 'last_export' => 'DESC' ] );
 
 	return $foo;
+}
+
+function display_network_storage() {
+	$storage = get_site_transient( 'pb_stats_network_storage' );
+	if ( empty( $storage ) ) {
+		$storage = format_bytes( recurse_dirsize( wp_upload_dir()['basedir'] ) );
+		set_site_transient( 'pb_stats_network_storage', $storage, DAY_IN_SECONDS );
+	}
+	printf( '<p>%1$s: %2$s</p>', __( 'Network Storage', 'pressbooks-stats' ), $storage );
 }

--- a/pressbooks-stats.php
+++ b/pressbooks-stats.php
@@ -60,3 +60,4 @@ register_activation_hook( __FILE__, '\PressbooksStats\Helpers\install' );
 add_action( 'pressbooks_track_export', '\PressbooksStats\Stats\track_export' );
 add_action( 'admin_init', '\PressbooksStats\Stats\init_css_js' );
 add_action( 'network_admin_menu', '\PressbooksStats\Stats\menu' );
+add_action( 'mu_rightnow_end', '\PressbooksStats\Stats\display_network_storage' );


### PR DESCRIPTION
This was in an mu-plugin and wasn't cached. It belongs here.