### PR TITLE
Handle symlinked directories

### DIFF
--- a/inc/stats/namespace.php
+++ b/inc/stats/namespace.php
@@ -493,7 +493,8 @@ function display_network_storage() {
 
 function calculate_network_storage() {
 	$path = realpath( wp_upload_dir()['basedir'] );
-	$storage = format_bytes( rtrim( str_replace( $path, '', `du -b -s $path` ) ) );
+	$output = exec( sprintf( 'du -b -s %s', escapeshellarg( $path ) ) );
+	$storage = format_bytes( rtrim( str_replace( $path, '', $output ) ) );
 	return $storage;
 }
 

--- a/inc/stats/namespace.php
+++ b/inc/stats/namespace.php
@@ -492,7 +492,7 @@ function display_network_storage() {
 }
 
 function calculate_network_storage() {
-	$path = wp_upload_dir()['basedir'];
+	$path = realpath( wp_upload_dir()['basedir'] );
 	$storage = format_bytes( rtrim( str_replace( $path, '', `du -b -s $path` ) ) );
 	return $storage;
 }


### PR DESCRIPTION
In Trellis systems, the uploads directory is a symlink, so we need to use realpath() to resolve the symlink to ensure that we get an accurate directory size.