### PR TITLE
feat: use WordPress plugin dependency feature

### DIFF
--- a/.github/workflows/standards-and-tests.yml
+++ b/.github/workflows/standards-and-tests.yml
@@ -15,12 +15,12 @@ jobs:
       matrix:
         php: [ 8.1, 8.2 ]
         os: [ ubuntu-20.04 ]
-        wordpress: [ 6.1.1, latest ]
+        wordpress: [ '6.5', latest ]
         include:
           - experimental: true
           - experimental: false
             php: 8.1
-            wordpress: 6.1.1
+            wordpress: '6.5'
 
     name: Test - PHP ${{ matrix.php }} - WP ${{ matrix.wordpress }}
 

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "require-dev": {
         "pressbooks/coding-standards": "^1.1",
-        "yoast/phpunit-polyfills": "^1.0.1"
+        "yoast/phpunit-polyfills": "^1.1"
     },
     "scripts": {
       "test": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6034c4bb39b16e0a5cc67c944e749269",
+    "content-hash": "cc2960c95f56646a03f486942ae17e22",
     "packages": [
         {
             "name": "composer/installers",
@@ -2414,16 +2414,16 @@
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "1.0.5",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "3b59adeef77fb1c03ff5381dbb9d68b0aaff3171"
+                "reference": "224e4a1329c03d8bad520e3fc4ec980034a4b212"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/3b59adeef77fb1c03ff5381dbb9d68b0aaff3171",
-                "reference": "3b59adeef77fb1c03ff5381dbb9d68b0aaff3171",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/224e4a1329c03d8bad520e3fc4ec980034a4b212",
+                "reference": "224e4a1329c03d8bad520e3fc4ec980034a4b212",
                 "shasum": ""
             },
             "require": {
@@ -2470,7 +2470,7 @@
                 "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2023-03-30T23:39:05+00:00"
+            "time": "2023-08-19T14:25:08+00:00"
         }
     ],
     "aliases": [],
@@ -2482,5 +2482,5 @@
         "php": "^8.1"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/pressbooks-stats.php
+++ b/pressbooks-stats.php
@@ -2,6 +2,8 @@
 /*
 Plugin Name: Pressbooks Stats
 Description: Pressbooks plugin which provides some basic activity statistics for a Pressbooks network.
+Requires at least: 6.5
+Requires Plugins: pressbooks
 Version: 1.9.0
 Pressbooks tested up to: 6.9.0
 Author: Pressbooks (Book Oven Inc.)
@@ -9,20 +11,6 @@ Author URI: https://pressbooks.org
 Network: True
 License: GPL v3 or later
 */
-
-// -------------------------------------------------------------------------------------------------------------------
-// Check minimum requirements
-// -------------------------------------------------------------------------------------------------------------------
-
-if ( ! function_exists( 'pb_meets_minimum_requirements' ) && ! @include_once( WP_PLUGIN_DIR . '/pressbooks/compatibility.php' ) ) { // @codingStandardsIgnoreLine
-	return add_action(
-		'admin_notices', function () {
-			echo '<div id="message" class="error fade"><p>' . __( 'Cannot find Pressbooks install.', 'pressbooks-stats' ) . '</p></div>';
-		}
-	);
-} elseif ( ! pb_meets_minimum_requirements() ) {
-	return;
-}
 
 // -------------------------------------------------------------------------------------------------------------------
 // Setup some defaults

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -17,7 +17,8 @@ require_once $_tests_dir . '/includes/functions.php';
  * Manually load the plugin being tested.
  */
 function _manually_load_plugin() {
-	require dirname( dirname( __FILE__ ) ) . '/pressbooks-stats.php';
+	require_once( __DIR__ . '/../../pressbooks/hm-autoloader.php' );
+	require_once( __DIR__ . '/../pressbooks-stats.php' );
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 


### PR DESCRIPTION
WordPress 6.5 (coming Tuesday) introduces [plugin dependencies](https://make.wordpress.org/core/2024/03/05/introducing-plugin-dependencies-in-wordpress-6-5/).

This means we can remove the `pb_meets_minimum_requirements` check.