### PR TITLE
feat: add update-pot workflow and pot base file

### DIFF
--- a/.github/workflows/update-pot.yml
+++ b/.github/workflows/update-pot.yml
@@ -1,0 +1,19 @@
+name: Update .pot file 🌐
+
+on:
+  push:
+    branches: [dev]
+    paths:
+      - "**/*.php"
+      - "**/*.js"
+  workflow_dispatch:
+
+jobs:
+  update-pot-file:
+    uses: pressbooks/reusable-workflows/.github/workflows/update-pot.yml@main
+    secrets: inherit
+    with:
+      domain: 'pressbooks-stats'
+      slug: 'pressbooks-stats'
+      package_name: 'Pressbooks Stats'
+      headers: '{"Report-Msgid-Bugs-To": "https://github.com/pressbooks/pressbooks-stats/issues"}'

--- a/languages/pressbooks-stats.pot
+++ b/languages/pressbooks-stats.pot
@@ -1,0 +1,47 @@
+# Copyright (C) 2025 Pressbooks (Book Oven Inc.)
+# This file is distributed under the GPL v3 or later.
+msgid ""
+msgstr ""
+"Project-Id-Version: Pressbooks Stats 1.10.1\n"
+"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-stats/\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2025-12-01T10:31:45+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"X-Generator: WP-CLI 2.13.0-alpha\n"
+"X-Domain: pressbooks-stats\n"
+
+#. Plugin Name of the plugin
+#: pressbooks-stats.php
+msgid "Pressbooks Stats"
+msgstr ""
+
+#. Description of the plugin
+#: pressbooks-stats.php
+msgid "Pressbooks plugin which provides some basic activity statistics for a Pressbooks network."
+msgstr ""
+
+#. Author of the plugin
+#: pressbooks-stats.php
+msgid "Pressbooks (Book Oven Inc.)"
+msgstr ""
+
+#. Author URI of the plugin
+#: pressbooks-stats.php
+msgid "https://pressbooks.org"
+msgstr ""
+
+#: inc/stats/namespace.php:137
+msgid "Calculating stats&hellip;"
+msgstr ""
+
+#: inc/stats/namespace.php:488
+msgid "Network Storage"
+msgstr ""
+
+#: inc/stats/namespace.php:501
+msgid "Calculating storage&hellip;"
+msgstr ""


### PR DESCRIPTION
Issue: https://github.com/pressbooks/private/issues/1969

This pull request introduces automation for updating translation files and adds a new `.pot` file for localization. The main changes are the addition of a GitHub Actions workflow to automatically update the `.pot` file when source files change, and the initial creation of the translation template file for the plugin.

**Localization automation:**

* Added `.github/workflows/update-pot.yml` workflow to automatically update the `.pot` file when changes are made to `.php` or `.js` files in the `dev` branch. This workflow uses a reusable workflow and passes necessary metadata for the plugin.

**Translation template:**

* Added new `languages/pressbooks-stats.pot` file containing all translatable strings and metadata for the Pressbooks Stats plugin, enabling easier localization and translation management.