### PR TITLE
chore: add text domain

### DIFF
--- a/pressbooks-stats.php
+++ b/pressbooks-stats.php
@@ -57,3 +57,7 @@ add_action( 'network_admin_menu', '\PressbooksStats\Stats\menu' );
 if ( ! defined( 'PB_DISABLE_NETWORK_STORAGE' ) || ! PB_DISABLE_NETWORK_STORAGE ) {
 	add_action( 'mu_rightnow_end', '\PressbooksStats\Stats\display_network_storage' );
 }
+
+add_action( 'admin_init', function() {
+	load_plugin_textdomain( 'pressbooks-stats', false, 'pressbooks-stats/languages/' );
+} );


### PR DESCRIPTION
Related issue: https://github.com/pressbooks/private/issues/2410

This pull request introduces an improvement to the plugin's internationalization support by ensuring that the text domain is loaded during the WordPress admin initialization process.

Internationalization:

* Hooks a function to the `admin_init` action to load the plugin's text domain from the `pressbooks-stats/languages/` directory, enabling translation support for the plugin.