### PR TITLE
chore: integrate crowdin

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -1,0 +1,57 @@
+name: Crowdin Translations Sync
+
+on:
+  push:
+    branches:
+      - dev
+    paths:
+      - 'languages/pressbooks-stats.pot'
+
+  schedule:
+    - cron: '0 0 * * *'
+
+  workflow_dispatch:
+    inputs:
+      action:
+        description: 'Action to perform'
+        type: choice
+        options:
+          - Pull Translations
+          - Seed Translations
+        default: Pull Translations
+
+jobs:
+  upload-sources:
+    name: Upload Sources
+    if: github.event_name == 'push'
+    uses: pressbooks/reusable-workflows/.github/workflows/crowdin.yml@main
+    with:
+      action: upload
+      pot_file_path: languages/pressbooks-stats.pot
+      crowdin_branch_name: pressbooks-stats
+      base_branch: dev
+    secrets: inherit
+
+  download-translations:
+    name: Pull Translations
+    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'Pull Translations')
+    uses: pressbooks/reusable-workflows/.github/workflows/crowdin.yml@main
+    with:
+      action: download
+      pot_file_path: languages/pressbooks-stats.pot
+      languages_dir: languages/
+      crowdin_branch_name: pressbooks-stats
+      base_branch: dev
+    secrets: inherit
+
+  seed-translations:
+    name: Seed Translations
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'Seed Translations'
+    uses: pressbooks/reusable-workflows/.github/workflows/crowdin.yml@main
+    with:
+      action: seed
+      pot_file_path: languages/pressbooks-stats.pot
+      languages_dir: languages/
+      crowdin_branch_name: pressbooks-stats
+      base_branch: dev
+    secrets: inherit

--- a/crodwin.yml
+++ b/crodwin.yml
@@ -1,0 +1,19 @@
+"project_id_env": "CROWDIN_OPEN_PROJECT_ID"
+"api_token_env": "CROWDIN_API_SECRET"
+"pull_request_title": "chore(l10n): update languages"
+"preserve_hierarchy": true
+"files": [
+  {
+    "source": "/languages/pressbooks-stats.pot",
+    "dest": "/languages/pressbooks-stats.pot",
+    "translation": "/languages/pressbooks-stats-%locale_with_underscore%.po",
+    "languages_mapping": {
+      "locale_with_underscore": {
+        "es-ES": "es_ES",
+        "es-MX": "es_MX",
+        "fr": "fr_FR",
+        "fr-CA": "fr_CA"
+      }
+    }
+  }
+]

--- a/pressbooks-stats.php
+++ b/pressbooks-stats.php
@@ -57,3 +57,7 @@ add_action( 'network_admin_menu', '\PressbooksStats\Stats\menu' );
 if ( ! defined( 'PB_DISABLE_NETWORK_STORAGE' ) || ! PB_DISABLE_NETWORK_STORAGE ) {
 	add_action( 'mu_rightnow_end', '\PressbooksStats\Stats\display_network_storage' );
 }
+
+add_action('init', function () {
+	load_plugin_textdomain( 'pressbooks-stats', false, 'pressbooks-stats/languages' );
+});

--- a/pressbooks-stats.php
+++ b/pressbooks-stats.php
@@ -10,6 +10,8 @@
  * Pressbooks tested up to: 6.18.0
  * Author: Pressbooks (Book Oven Inc.)
  * Author URI: https://pressbooks.org
+ * Text Domain: pressbooks-stats
+ * Domain Path: /languages
  * Network: True
  * License: GPL v3 or later
  *


### PR DESCRIPTION
Issue: https://github.com/pressbooks/private/issues/2454

This pull request introduces automated Crowdin translation syncing for the project and adds configuration to support localization. The main changes include setting up a GitHub Actions workflow for syncing translations, adding a Crowdin configuration file, and ensuring the plugin loads its text domain for localization.

**Crowdin integration and workflow automation:**

* Added a new GitHub Actions workflow in `.github/workflows/crowdin.yml` to automate uploading source strings, pulling translations, and seeding translations via reusable workflows, triggered by pushes, schedules, or manual dispatch.
* Introduced a `crodwin.yml` configuration file to define Crowdin project settings, file mappings, and language code mappings for the translation process.

**Localization support:**

* Updated `pressbooks-stats.php` to load the plugin text domain on `init`, enabling translation of plugin strings through the newly integrated Crowdin workflow.